### PR TITLE
working in a py3 conda env at NSLS-II

### DIFF
--- a/carchive/backend/classic.py
+++ b/carchive/backend/classic.py
@@ -402,7 +402,7 @@ class Archive(object):
             Tcur, Tend = timeTuple(T0), timeTuple(Tend)
 
         _log.debug("Time range: %s -> %s", Tcur, Tend)
-        _log.debug("Planning with: %s", map(lambda (a,b,c):(a,b,self.__rarchs[c]), breakDown))
+        _log.debug("Planning with: %s", map(lambda a,b,c:(a,b,self.__rarchs[c]), breakDown))
 
         plan = []
         
@@ -456,7 +456,7 @@ class Archive(object):
             _log.warn("Query plan empty.  No data in or before request time range.")
             defer.returnValue(0)
 
-        _log.debug("Using plan of %d queries %s", len(plan), map(lambda (a,b,c):(a,b,self.__rarchs[c]), plan))
+        _log.debug("Using plan of %d queries %s", len(plan), map(lambda a,b,c:(a,b,self.__rarchs[c]), plan))
 
         N = yield self._nextraw(0, pv=pv, plan=plan,
                                 Ctot=0, Climit=count,
@@ -533,7 +533,7 @@ class Archive(object):
         Tcur, Tend = timeTuple(T0), timeTuple(Tend)
 
         _log.debug("Time range: %s -> %s", Tcur, Tend)
-        _log.debug("Planning with: %s", map(lambda (a,b,c):(a,b,self.__rarchs[c]), breakDown))
+        _log.debug("Planning with: %s", map(lambda a,b,c:(a,b,self.__rarchs[c]), breakDown))
 
         N = 0
         # Plan queries

--- a/carchive/backend/pbdecode.cpp
+++ b/carchive/backend/pbdecode.cpp
@@ -689,7 +689,7 @@ static struct PyModuleDef pbdmod = {
 #endif
 
 PyMODINIT_FUNC
-initpbdecode(void)
+PyInit_pbdecode(void)
 {
     PyRef map(PyDict_New());
     PyObject *mod;
@@ -700,7 +700,7 @@ initpbdecode(void)
     GOOGLE_PROTOBUF_VERIFY_VERSION;
 
 #if PY_MAJOR_VERSION >= 3
-    mod - PyModule_Create(&pbdmod);
+    mod = PyModule_Create(&pbdmod);
 #else
     mod = Py_InitModule(moduleName, PBDMethods);
 #endif

--- a/carchive/cmd/get.py
+++ b/carchive/cmd/get.py
@@ -70,7 +70,11 @@ def cmd(archive=None, opt=None, args=None, conf=None, breakDown=None, **kws):
 
     _log.debug("Time range: %s -> %s", T0, Tend)
 
-    count = opt.count if opt.count>0 else conf.getint('defaultcount')
+    count = (
+        opt.count
+        if (opt.count is not None) and opt.count > 0
+        else conf.getint('defaultcount')
+    )
 
     for pv in args:
         printData = Printer(opt, pv)

--- a/carchive/cmd/get.py
+++ b/carchive/cmd/get.py
@@ -24,7 +24,8 @@ class Printer(object):
         else:
             raise ValueError("Invalid time format %s"%opt.timefmt)
 
-    def timeposix(self, (sec,ns)):
+    def timeposix(self, sec_ns_tup):
+        sec, ns = sec_ns_tup
         return sec+1e-9*ns
 
     def timestring(self, ts):

--- a/carchive/cmd/h5export.py
+++ b/carchive/cmd/h5export.py
@@ -87,7 +87,11 @@ def cmd(archive=None, opt=None, args=None, conf=None, **kws):
     T0, Tend = makeTimeInterval(opt.start, opt.end)
     TT0, TT1 = timeTuple(T0), timeTuple(Tend)
 
-    count = opt.count if opt.count>0 else conf.getint('defaultcount')
+    count = (
+        opt.count
+        if (opt.count is not None) and opt.count > 0
+        else conf.getint('defaultcount')
+    )
 
     h5file, _, path = opt.h5file.partition(':')
     if path=='':

--- a/carchive/cmd/info.py
+++ b/carchive/cmd/info.py
@@ -12,7 +12,7 @@ def cmd(archive=None, opt=None, conf=None, **kws):
     if opt.verbose>1:
         conf.write(sys.stdout)
         sys.stdout.write('\n')
-        print archive
+        print(archive)
 
     archs=set()
     for ar in opt.archive:
@@ -20,7 +20,7 @@ def cmd(archive=None, opt=None, conf=None, **kws):
     archs=list(archs)
 
     if opt.verbose>0:
-      print('Archives:')
+        print('Archives:')
     archs.sort()
     for ar in archs:
         print(ar)

--- a/carchive/cmd/snap.py
+++ b/carchive/cmd/snap.py
@@ -20,7 +20,8 @@ def cmd(archive=None, opt=None, args=None, conf=None, **kws):
         def timefmt(ts):
             return makeTime(ts)
     elif opt.timefmt=='posix':
-        def timefmt((sec,ns)):
+        def timefmt(sec_ns_tup):
+            sec,ns = sec_ns_tup
             return sec+1e-9*ns
     else:
         raise ValueError("Invalid time format %s"%opt.timefmt)

--- a/carchive/date.py
+++ b/carchive/date.py
@@ -193,7 +193,7 @@ def _fromAbsString(intime, now):
     parts = [int(v) if v else d for v,d in zip(parts[:6], D)]
     parts += [0,0,-1] # disable DST compensation
 
-    return int(conv(parts)), int(nsec)
+    return int(conv(tuple(parts))), int(nsec)
 
 def timeTuple(dt):
     """Convert (local) datetime object to (sec, nsec)
@@ -319,7 +319,7 @@ def makeTime(intime, now=None):
         S=tv//1
         NS=(tv%1)*1e9
         intime=(int(S), int(NS))
-    elif isinstance(intime, (int, long)):
+    elif isinstance(intime, int):
         intime = (intime, 0)
 
     if isinstance(intime, tuple):
@@ -328,7 +328,7 @@ def makeTime(intime, now=None):
         S+=datetime.timedelta(microseconds=NS/1000)
         return S
 
-    if not isinstance(intime, (str,unicode)):
+    if not isinstance(intime, str):
         raise ValueError('Input must be a tuple, number, or string.  Not %s'%type(intime))
 
     intime=intime.strip().lower()

--- a/carchive/rpcmunge.py
+++ b/carchive/rpcmunge.py
@@ -17,7 +17,8 @@ _log = logging.getLogger("carchive.rpcmunge")
 from twisted.internet import defer
 
 #from twisted.web.http import HTTPClient
-from twisted.web.xmlrpc import QueryProtocol, _QueryFactory, Proxy
+from twisted.web.xmlrpc import QueryProtocol, Proxy
+from twisted.web.xmlrpc import QueryFactory as _QueryFactory
 
 class NiceQueryProtocol(QueryProtocol):
     def lineReceived(self, line):

--- a/carchive/untwisted.py
+++ b/carchive/untwisted.py
@@ -167,10 +167,10 @@ def arget(names, match = WILDCARD, mode = RAW,
     and N is the maximum number of samples of any time point (N=1 for scalars).
     """
     scalar = False
-    if isinstance(names, (str, unicode)):
+    if isinstance(names, str):
         scalar, names = True, [names]
     if scalar:
-      assert len(names)==1, str(names)
+        assert len(names)==1, str(names)
 
     if mode==PLOTBIN and count is None:
         raise ValueError("PLOTBIN requires sample count")

--- a/carchive/util.py
+++ b/carchive/util.py
@@ -211,13 +211,15 @@ class BufferingLineProtocol(protocol.Protocol):
         # trick cStringIO to allocate the full buffer size
         # to allow append w/o re-alloc
         self.rxbuf.seek(self.rx_buf_size+1024)
-        self.rxbuf.write(b'x')
+        self.rxbuf.write('x')
+        self.rxbuf.seek(0) # Critical to have this line for Py-3
         self.rxbuf.truncate(0)
 
         self._nbytes, self._tstart = 0, time.time()
         self._tend = None
 
     def dataReceived(self, data):
+        data = data.decode('iso-8859-1')
         self._nbytes += len(data)
         self.rxbuf.write(data)
         if self.rxbuf.tell()<self.rx_buf_size:


### PR DESCRIPTION
No systematic testing was performed, but the `arget` terminal command and some existing Python scripts that depend on this package works as expected on a RHEL8 server with a Py-3 conda environment at NSLS-II.

I think the changes I made are NOT backward compatible to Py-2. If the backward compatibility is a requirement, please feel free to modify accordingly.