### PR TITLE
bdist_wheel works with this change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ class LinkScripts(Command):
         self.links = self.distribution.x_link_scripts or ()
     def run(self):
         from os.path import join
+        self.mkpath(self.install_dir)
         for target, dest in self.links:
             self.copy_file(target,
                            join(self.install_dir, dest),


### PR DESCRIPTION
`python setup.py bdist_wheel` was failing without this change, even though `python setup.py install` was working.